### PR TITLE
Iterate on the shared memory PR

### DIFF
--- a/c++/mpi/communicator.hpp
+++ b/c++/mpi/communicator.hpp
@@ -31,14 +31,17 @@
 
 namespace mpi {
 
+  // Forward declaration.
   class shared_communicator;
 
   /**
    * @ingroup mpi_essentials
    * @brief C++ wrapper around `MPI_Comm` providing various convenience functions.
    *
-   * @details It stores an `MPI_Comm` object as its only member which by default is set to `MPI_COMM_WORLD`.
-   * Note that copying the communicator simply copies the `MPI_Comm` object, without calling `MPI_Comm_dup`.
+   * @details It stores an `MPI_Comm` object as its only member which by default is set to `MPI_COMM_WORLD`. The
+   * underlying `MPI_Comm` object is not freed when a communicator goes out of scope. It is the user's responsibility to
+   * do so, in case it is needed. Note that copying the communicator simply copies the `MPI_Comm` object, without
+   * calling `MPI_Comm_dup`.
    *
    * All functions that make direct calls to the MPI C library throw an exception in case the call fails.
    */
@@ -50,12 +53,14 @@ namespace mpi {
     /**
      * @brief Construct a communicator with a given `MPI_Comm` object.
      * @details The `MPI_Comm` object is copied without calling `MPI_Comm_dup`.
+     * @param c `MPI_Comm` object to wrap.
      */
     communicator(MPI_Comm c) : com_(c) {}
 
     /// Get the wrapped `MPI_Comm` object.
     [[nodiscard]] MPI_Comm get() const noexcept { return com_; }
 
+    /// Check if the contained `MPI_Comm` is `MPI_COMM_NULL`.
     [[nodiscard]] bool is_null() const noexcept { return com_ == MPI_COMM_NULL; }
 
     /**
@@ -81,12 +86,15 @@ namespace mpi {
     /**
      * @brief Split the communicator into disjoint subgroups.
      *
-     * @details Calls `MPI_Comm_split` with the given color and key arguments. See the MPI documentation for more details,
-     * e.g. <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_split.3.html">open-mpi docs</a>.
+     * @details Calls `MPI_Comm_split` with the given color and key arguments. See the MPI documentation for more
+     * details, e.g. <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_split.3.html">open-mpi
+     * docs</a>.
      *
-     * @warning This allocates a new communicator object. Make sure to call `free` on the returned communicator when
-     * it is no longer needed.
+     * @warning This allocates a new communicator object. Make sure to call free() on the returned communicator when it
+     * is no longer needed.
      *
+     * @param color Determines which processes are put into the same group.
+     * @param key Determines the rank of the process in the new communicator.
      * @return If mpi::has_env is true, return the split `MPI_Comm` object wrapped in a new mpi::communicator, otherwise
      * return a default constructed mpi::communicator.
      */
@@ -96,6 +104,20 @@ namespace mpi {
       return c;
     }
 
+    /**
+     * @brief Partition the communicator into subcommunicators according to their type.
+     *
+     * @details In the MPI3.0 standard the only supported split type is `MPI_COMM_TYPE_SHARED`. OpenMPI (and possibly
+     * other implementations) provide more custom split types, however, they are not portable.
+     *
+     * @warning This allocates a new communicator object. Make sure to call free on the returned communicator when it
+     * is no longer needed.
+     *
+     * @param split_type Type of processes to be grouped together.
+     * @param key Determines the rank of the process in the new communicator.
+     * @return If mpi::has_env is true, return the split `MPI_Comm` object wrapped in a new mpi::communicator, otherwise
+     * return a default constructed mpi::communicator.
+     */
     [[nodiscard]] shared_communicator split_shared(int split_type = MPI_COMM_TYPE_SHARED, int key = 0) const;
 
     /**
@@ -104,8 +126,8 @@ namespace mpi {
      * @details Calls `MPI_Comm_dup` to duplicate the communicator. See the MPI documentation for more details, e.g.
      * <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_dup.3.html">open-mpi docs</a>.
      *
-     * @warning This allocates a new communicator object. Make sure to call `free` on the returned communicator when
-     * it is no longer needed.
+     * @warning This allocates a new communicator object. Make sure to call free on the returned communicator when it
+     * is no longer needed.
      *
      * @return If mpi::has_env is true, return the duplicated `MPI_Comm` object wrapped in a new mpi::communicator,
      * otherwise return a default constructed mpi::communicator.
@@ -130,7 +152,7 @@ namespace mpi {
     }
 
     /**
-     * @brief If mpi::has_env is true, `MPI_Abort` is called with the given error code, otherwise std::abort is called.
+     * @brief If mpi::has_env is true, `MPI_Abort` is called with the given error code, otherwise it calls `std::abort`.
      * @param error_code The error code to pass to `MPI_Abort`.
      */
     void abort(int error_code) const {
@@ -150,17 +172,18 @@ namespace mpi {
     /**
      * @brief Barrier synchronization.
      *
-     * @details Does nothing if mpi::has_env is false. Otherwise, it either uses a blocking `MPI_Barrier`
-     * (if the given argument is 0) or a non-blocking `MPI_Ibarrier` call. The given parameter determines
-     * in milliseconds how often each process calls `MPI_Test` to check if all processes have reached the barrier.
+     * @details Does nothing if mpi::has_env is false. Otherwise, it either uses a blocking `MPI_Barrier` (if the given
+     * argument is 0) or a non-blocking `MPI_Ibarrier` call. The given parameter determines in milliseconds how often
+     * each process calls `MPI_Test` to check if all processes have reached the barrier.
+     *
      * This can considerably reduce the CPU load:
-     *     - 1 msec ~ 1% cpu load
-     *     - 10 msec ~ 0.5% cpu load
-     *     - 100 msec ~ 0.01% cpu load
+     * - 1 msec ~ 1% cpu load
+     * - 10 msec ~ 0.5% cpu load
+     * - 100 msec ~ 0.01% cpu load
      *
      * For a very unbalanced load that takes a long time to finish, 1000 msec is a good choice.
      *
-     * @param poll_msec The polling interval in milliseconds. If set to 0, a simple `MPI_Barrier` call is used.
+     * @param poll_msec Polling interval in milliseconds. If set to 0, a simple `MPI_Barrier` call is used.
      */
     void barrier(long poll_msec = 1) const {
       if (has_env) {
@@ -184,31 +207,21 @@ namespace mpi {
 
   /**
    * @ingroup mpi_osc_shm
-   * @brief C++ wrapper around @p MPI_Comm that is a result of the @p split_shared operation.
+   * @brief C++ wrapper around `MPI_Comm` that is a result of the mpi::communicator::split_shared operation.
    *
-   * @details In the plain MPI C API it is not distinguishable whether an @p
-   * MPI_Comm is local to a shared memory island or not. Thus we introduce an
-   * extra type for that whose only purpose is to make that distinction on the
-   * type-level to prevent wrong usage of the shared memory APIs.
+   * @details In the plain MPI C API it is not distinguishable whether an `MPI_Comm` is local to a shared memory island
+   * or not. Thus we introduce an extra type for that whose only purpose is to make that distinction on the type-level
+   * to prevent wrong usage of the shared memory APIs.
    */
   class shared_communicator : public communicator {
     public:
+    // Make the constructors of mpi::communicator accessible.
     using communicator::communicator;
+
+    /// Construct a shared communicator with `MPI_COMM_NULL`.
     shared_communicator() : communicator(MPI_COMM_NULL) {}
   };
 
-  /**
-   * @brief Partition the communicator into subcommunicators according to their type.
-   *
-   * @details In the MPI3.0 standard the only supported split type is @p
-   * MPI_COMM_TYPE_SHARED. OpenMPI (and possibly other implementations) provide
-   * more custom split types, however, they are not portable.
-   *
-   * @param split_type Type of processes to be grouped together.
-   * @param key Control of rank assignment.
-   *
-   * @return New communicator.
-   */
   [[nodiscard]] inline shared_communicator communicator::split_shared(int split_type, int key) const {
     shared_communicator c{};
     if (has_env) check_mpi_call(MPI_Comm_split_type(com_, split_type, key, MPI_INFO_NULL, &c.com_), "MPI_Comm_split_type");

--- a/c++/mpi/communicator.hpp
+++ b/c++/mpi/communicator.hpp
@@ -43,8 +43,6 @@ namespace mpi {
    * All functions that make direct calls to the MPI C library throw an exception in case the call fails.
    */
   class communicator {
-    friend class shared_communicator;
-
     public:
     /// Construct a communicator with `MPI_COMM_WORLD`.
     communicator() = default;
@@ -65,12 +63,9 @@ namespace mpi {
      * @return The result of `MPI_Comm_rank` if mpi::has_env is true, otherwise 0.
      */
     [[nodiscard]] int rank() const {
-      if (has_env) {
-        int num = 0;
-        check_mpi_call(MPI_Comm_rank(com_, &num), "MPI_Comm_rank");
-        return num;
-      } else
-        return 0;
+      int r = 0;
+      if (has_env) check_mpi_call(MPI_Comm_rank(com_, &r), "MPI_Comm_rank");
+      return r;
     }
 
     /**
@@ -78,12 +73,9 @@ namespace mpi {
      * @return The result of `MPI_Comm_size` if mpi::has_env is true, otherwise 1.
      */
     [[nodiscard]] int size() const {
-      if (has_env) {
-        int num = 0;
-        check_mpi_call(MPI_Comm_size(com_, &num), "MPI_Comm_size");
-        return num;
-      } else
-        return 1;
+      int s = 1;
+      if (has_env) check_mpi_call(MPI_Comm_size(com_, &s), "MPI_Comm_size");
+      return s;
     }
 
     /**
@@ -99,12 +91,9 @@ namespace mpi {
      * return a default constructed mpi::communicator.
      */
     [[nodiscard]] communicator split(int color, int key = 0) const {
-      if (has_env) {
-        communicator c;
-        check_mpi_call(MPI_Comm_split(com_, color, key, &c.com_), "MPI_Comm_split");
-        return c;
-      } else
-        return {};
+      communicator c{};
+      if (has_env) check_mpi_call(MPI_Comm_split(com_, color, key, &c.com_), "MPI_Comm_split");
+      return c;
     }
 
     [[nodiscard]] shared_communicator split_shared(int split_type = MPI_COMM_TYPE_SHARED, int key = 0) const;
@@ -122,12 +111,9 @@ namespace mpi {
      * otherwise return a default constructed mpi::communicator.
      */
     [[nodiscard]] communicator duplicate() const {
-      if (has_env) {
-        communicator c;
-        check_mpi_call(MPI_Comm_dup(com_, &c.com_), "MPI_Comm_dup");
-        return c;
-      } else
-        return {};
+      communicator c{};
+      if (has_env) check_mpi_call(MPI_Comm_dup(com_, &c.com_), "MPI_Comm_dup");
+      return c;
     }
 
     /**
@@ -140,7 +126,7 @@ namespace mpi {
      * Does nothing, if mpi::has_env is false.
      */
     void free() {
-      if (has_env) { check_mpi_call(MPI_Comm_free(&com_), "MPI_Comm_free"); }
+      if (has_env && !is_null()) check_mpi_call(MPI_Comm_free(&com_), "MPI_Comm_free");
     }
 
     /**
@@ -148,10 +134,11 @@ namespace mpi {
      * @param error_code The error code to pass to `MPI_Abort`.
      */
     void abort(int error_code) const {
-      if (has_env)
+      if (has_env) {
         check_mpi_call(MPI_Abort(com_, error_code), "MPI_Abort");
-      else
+      } else {
         std::abort();
+      }
     }
 
 #ifdef BOOST_MPI_HPP
@@ -223,12 +210,9 @@ namespace mpi {
    * @return New communicator.
    */
   [[nodiscard]] inline shared_communicator communicator::split_shared(int split_type, int key) const {
-    if (has_env) {
-      shared_communicator c;
-      MPI_Comm_split_type(com_, split_type, key, MPI_INFO_NULL, &c.com_);
-      return c;
-    } else
-      return {};
+    shared_communicator c{};
+    if (has_env) check_mpi_call(MPI_Comm_split_type(com_, split_type, key, MPI_INFO_NULL, &c.com_), "MPI_Comm_split_type");
+    return c;
   }
 
 } // namespace mpi

--- a/c++/mpi/communicator.hpp
+++ b/c++/mpi/communicator.hpp
@@ -44,8 +44,6 @@ namespace mpi {
    */
   class communicator {
     friend class shared_communicator;
-    // Wrapped `MPI_Comm` object.
-    MPI_Comm _com = MPI_COMM_WORLD;
 
     public:
     /// Construct a communicator with `MPI_COMM_WORLD`.
@@ -55,12 +53,12 @@ namespace mpi {
      * @brief Construct a communicator with a given `MPI_Comm` object.
      * @details The `MPI_Comm` object is copied without calling `MPI_Comm_dup`.
      */
-    communicator(MPI_Comm c) : _com(c) {}
+    communicator(MPI_Comm c) : com_(c) {}
 
     /// Get the wrapped `MPI_Comm` object.
-    [[nodiscard]] MPI_Comm get() const noexcept { return _com; }
+    [[nodiscard]] MPI_Comm get() const noexcept { return com_; }
 
-    [[nodiscard]] bool is_null() const noexcept { return _com == MPI_COMM_NULL; }
+    [[nodiscard]] bool is_null() const noexcept { return com_ == MPI_COMM_NULL; }
 
     /**
      * @brief Get the rank of the calling process in the communicator.
@@ -69,7 +67,7 @@ namespace mpi {
     [[nodiscard]] int rank() const {
       if (has_env) {
         int num = 0;
-        check_mpi_call(MPI_Comm_rank(_com, &num), "MPI_Comm_rank");
+        check_mpi_call(MPI_Comm_rank(com_, &num), "MPI_Comm_rank");
         return num;
       } else
         return 0;
@@ -82,7 +80,7 @@ namespace mpi {
     [[nodiscard]] int size() const {
       if (has_env) {
         int num = 0;
-        check_mpi_call(MPI_Comm_size(_com, &num), "MPI_Comm_size");
+        check_mpi_call(MPI_Comm_size(com_, &num), "MPI_Comm_size");
         return num;
       } else
         return 1;
@@ -103,7 +101,7 @@ namespace mpi {
     [[nodiscard]] communicator split(int color, int key = 0) const {
       if (has_env) {
         communicator c;
-        check_mpi_call(MPI_Comm_split(_com, color, key, &c._com), "MPI_Comm_split");
+        check_mpi_call(MPI_Comm_split(com_, color, key, &c.com_), "MPI_Comm_split");
         return c;
       } else
         return {};
@@ -126,7 +124,7 @@ namespace mpi {
     [[nodiscard]] communicator duplicate() const {
       if (has_env) {
         communicator c;
-        check_mpi_call(MPI_Comm_dup(_com, &c._com), "MPI_Comm_dup");
+        check_mpi_call(MPI_Comm_dup(com_, &c.com_), "MPI_Comm_dup");
         return c;
       } else
         return {};
@@ -142,7 +140,7 @@ namespace mpi {
      * Does nothing, if mpi::has_env is false.
      */
     void free() {
-      if (has_env) { check_mpi_call(MPI_Comm_free(&_com), "MPI_Comm_free"); }
+      if (has_env) { check_mpi_call(MPI_Comm_free(&com_), "MPI_Comm_free"); }
     }
 
     /**
@@ -151,7 +149,7 @@ namespace mpi {
      */
     void abort(int error_code) const {
       if (has_env)
-        check_mpi_call(MPI_Abort(_com, error_code), "MPI_Abort");
+        check_mpi_call(MPI_Abort(com_, error_code), "MPI_Abort");
       else
         std::abort();
     }
@@ -180,11 +178,11 @@ namespace mpi {
     void barrier(long poll_msec = 1) const {
       if (has_env) {
         if (poll_msec == 0) {
-          check_mpi_call(MPI_Barrier(_com), "MPI_Barrier");
+          check_mpi_call(MPI_Barrier(com_), "MPI_Barrier");
         } else {
           MPI_Request req{};
           int flag = 0;
-          check_mpi_call(MPI_Ibarrier(_com, &req), "MPI_Ibarrier");
+          check_mpi_call(MPI_Ibarrier(com_, &req), "MPI_Ibarrier");
           while (!flag) {
             check_mpi_call(MPI_Test(&req, &flag, MPI_STATUS_IGNORE), "MPI_Test");
             usleep(poll_msec * 1000);
@@ -192,6 +190,9 @@ namespace mpi {
         }
       }
     }
+
+    private:
+    MPI_Comm com_ = MPI_COMM_WORLD;
   };
 
   /**
@@ -224,7 +225,7 @@ namespace mpi {
   [[nodiscard]] inline shared_communicator communicator::split_shared(int split_type, int key) const {
     if (has_env) {
       shared_communicator c;
-      MPI_Comm_split_type(_com, split_type, key, MPI_INFO_NULL, &c._com);
+      MPI_Comm_split_type(com_, split_type, key, MPI_INFO_NULL, &c.com_);
       return c;
     } else
       return {};

--- a/c++/mpi/group.hpp
+++ b/c++/mpi/group.hpp
@@ -23,11 +23,12 @@
 
 #include "./communicator.hpp"
 #include "./environment.hpp"
+#include "./utils.hpp"
 
 #include <mpi.h>
 
-#include <cstdlib>
-#include <unistd.h>
+#include <utility>
+#include <vector>
 
 namespace mpi {
 
@@ -54,14 +55,14 @@ namespace mpi {
     /// Move assignment operator leaves moved-from object with @p MPI_GROUP_NULL.
     group &operator=(group &&rhs) noexcept {
       if (this != std::addressof(rhs)) {
-        this->free();
-        this->grp_ = std::exchange(rhs.grp_, MPI_GROUP_NULL);
+        free();
+        grp_ = std::exchange(rhs.grp_, MPI_GROUP_NULL);
       }
       return *this;
     }
 
     /// Destructor
-    virtual ~group() { free(); }
+    ~group() { free(); }
 
     /**
      * @brief Take ownership of an existing @p MPI_Group object.
@@ -74,7 +75,7 @@ namespace mpi {
      * @param c The communicator from which to create a group.
      */
     explicit group(communicator c) {
-      if (has_env) { MPI_Comm_group(c.get(), &grp_); }
+      if (has_env) check_mpi_call(MPI_Comm_group(c.get(), &grp_), "MPI_Comm_group");
     }
 
     /// Get the wrapped @p MPI_Group object.
@@ -85,16 +86,16 @@ namespace mpi {
 
     /// Rank of the calling process in the given group.
     [[nodiscard]] int rank() const {
-      int rank = 0;
-      if (has_env) { MPI_Group_rank(grp_, &rank); }
-      return rank;
+      int r = 0;
+      if (has_env) check_mpi_call(MPI_Group_rank(grp_, &r), "MPI_Group_rank");
+      return r;
     }
 
     /// Size of a group.
     [[nodiscard]] int size() const {
-      int size = 1;
-      if (has_env) { MPI_Group_size(grp_, &size); }
-      return size;
+      int s = 1;
+      if (has_env) check_mpi_call(MPI_Group_size(grp_, &s), "MPI_Group_size");
+      return s;
     }
 
     /**
@@ -102,17 +103,15 @@ namespace mpi {
      * @param ranks List of ranks to include in the new group.
      * @return New group containing only the listed members.
      */
-    group include(std::vector<int> const &ranks) const {
+    [[nodiscard]] group include(std::vector<int> const &ranks) const {
       MPI_Group newgroup = MPI_GROUP_NULL;
-      if (has_env) { MPI_Group_incl(grp_, ranks.size(), ranks.data(), &newgroup); }
-      return group(newgroup);
+      if (has_env) check_mpi_call(MPI_Group_incl(grp_, static_cast<int>(ranks.size()), ranks.data(), &newgroup), "MPI_Group_incl");
+      return group{newgroup};
     }
 
     /// Free the group.
-    void free() {
-      if (has_env) {
-        if (grp_ != MPI_GROUP_NULL) { MPI_Group_free(&grp_); }
-      }
+    void free() noexcept {
+      if (has_env && !is_null()) MPI_Group_free(&grp_);
     }
 
     private:

--- a/c++/mpi/group.hpp
+++ b/c++/mpi/group.hpp
@@ -38,9 +38,6 @@ namespace mpi {
    * @details It stores an @p MPI_Group object as its only member which by default is set to @p MPI_GROUP_NULL.
    */
   class group {
-    // Wrapped @p MPI_Group object.
-    MPI_Group _grp = MPI_GROUP_NULL;
-
     public:
     /// Construct a group with @p MPI_GROUP_NULL.
     group() = default;
@@ -52,13 +49,13 @@ namespace mpi {
     group &operator=(group const &) = delete;
 
     /// Move constructor leaves moved-from object with @p MPI_GROUP_NULL.
-    group(group &&other) noexcept : _grp{std::exchange(other._grp, MPI_GROUP_NULL)} {}
+    group(group &&other) noexcept : grp_{std::exchange(other.grp_, MPI_GROUP_NULL)} {}
 
     /// Move assignment operator leaves moved-from object with @p MPI_GROUP_NULL.
     group &operator=(group &&rhs) noexcept {
       if (this != std::addressof(rhs)) {
         this->free();
-        this->_grp = std::exchange(rhs._grp, MPI_GROUP_NULL);
+        this->grp_ = std::exchange(rhs.grp_, MPI_GROUP_NULL);
       }
       return *this;
     }
@@ -70,33 +67,33 @@ namespace mpi {
      * @brief Take ownership of an existing @p MPI_Group object.
      * @param grp The group to be handled.
      */
-    explicit group(MPI_Group grp) : _grp(grp) {}
+    explicit group(MPI_Group grp) : grp_(grp) {}
 
     /**
      * @brief Create a group from a communicator.
      * @param c The communicator from which to create a group.
      */
     explicit group(communicator c) {
-      if (has_env) { MPI_Comm_group(c.get(), &_grp); }
+      if (has_env) { MPI_Comm_group(c.get(), &grp_); }
     }
 
     /// Get the wrapped @p MPI_Group object.
-    [[nodiscard]] MPI_Group get() const noexcept { return _grp; }
+    [[nodiscard]] MPI_Group get() const noexcept { return grp_; }
 
     /// Check if the contained @p MPI_Group is @p MPI_GROUP_NULL.
-    [[nodiscard]] bool is_null() const noexcept { return _grp == MPI_GROUP_NULL; }
+    [[nodiscard]] bool is_null() const noexcept { return grp_ == MPI_GROUP_NULL; }
 
     /// Rank of the calling process in the given group.
     [[nodiscard]] int rank() const {
       int rank = 0;
-      if (has_env) { MPI_Group_rank(_grp, &rank); }
+      if (has_env) { MPI_Group_rank(grp_, &rank); }
       return rank;
     }
 
     /// Size of a group.
     [[nodiscard]] int size() const {
       int size = 1;
-      if (has_env) { MPI_Group_size(_grp, &size); }
+      if (has_env) { MPI_Group_size(grp_, &size); }
       return size;
     }
 
@@ -107,16 +104,19 @@ namespace mpi {
      */
     group include(std::vector<int> const &ranks) const {
       MPI_Group newgroup = MPI_GROUP_NULL;
-      if (has_env) { MPI_Group_incl(_grp, ranks.size(), ranks.data(), &newgroup); }
+      if (has_env) { MPI_Group_incl(grp_, ranks.size(), ranks.data(), &newgroup); }
       return group(newgroup);
     }
 
     /// Free the group.
     void free() {
       if (has_env) {
-        if (_grp != MPI_GROUP_NULL) { MPI_Group_free(&_grp); }
+        if (grp_ != MPI_GROUP_NULL) { MPI_Group_free(&grp_); }
       }
     }
+
+    private:
+    MPI_Group grp_ = MPI_GROUP_NULL;
   };
 
 } // namespace mpi

--- a/c++/mpi/group.hpp
+++ b/c++/mpi/group.hpp
@@ -16,7 +16,7 @@
 
 /**
  * @file
- * @brief Provides a C++ wrapper class for an @p MPI_Group object.
+ * @brief Provides a C++ wrapper class for an `MPI_Group` object.
  */
 
 #pragma once
@@ -34,13 +34,16 @@ namespace mpi {
 
   /**
    * @ingroup mpi_essentials
-   * @brief C++ wrapper around @p MPI_Group providing various convenience functions.
+   * @brief C++ wrapper around `MPI_Group` providing various convenience functions.
    *
-   * @details It stores an @p MPI_Group object as its only member which by default is set to @p MPI_GROUP_NULL.
+   * @details It stores an `MPI_Group` object as its only member which by default is set to `MPI_GROUP_NULL`. The
+   * underlying `MPI_Group` object is automatically freed when a group object goes out of scope.
+   *
+   * All functions that make direct calls to the MPI C library throw an exception in case the call fails.
    */
   class group {
     public:
-    /// Construct a group with @p MPI_GROUP_NULL.
+    /// Construct a group with `MPI_GROUP_NULL`.
     group() = default;
 
     /// Deleted copy constructor.
@@ -49,10 +52,10 @@ namespace mpi {
     /// Deleted copy assignment operator.
     group &operator=(group const &) = delete;
 
-    /// Move constructor leaves moved-from object with @p MPI_GROUP_NULL.
+    /// Move constructor leaves moved-from object with `MPI_GROUP_NULL`.
     group(group &&other) noexcept : grp_{std::exchange(other.grp_, MPI_GROUP_NULL)} {}
 
-    /// Move assignment operator leaves moved-from object with @p MPI_GROUP_NULL.
+    /// Move assignment operator leaves moved-from object with `MPI_GROUP_NULL`.
     group &operator=(group &&rhs) noexcept {
       if (this != std::addressof(rhs)) {
         free();
@@ -61,37 +64,43 @@ namespace mpi {
       return *this;
     }
 
-    /// Destructor
+    /// Destructor calls free() to release the group.
     ~group() { free(); }
 
     /**
-     * @brief Take ownership of an existing @p MPI_Group object.
-     * @param grp The group to be handled.
+     * @brief Take ownership of an existing `MPI_Group` object.
+     * @param grp `MPI_Group` to be handled.
      */
     explicit group(MPI_Group grp) : grp_(grp) {}
 
     /**
-     * @brief Create a group from a communicator.
-     * @param c The communicator from which to create a group.
+     * @brief Create a group from a communicator by calling `MPI_Comm_group`.
+     * @param c mpi::communicator from which to create a group.
      */
     explicit group(communicator c) {
       if (has_env) check_mpi_call(MPI_Comm_group(c.get(), &grp_), "MPI_Comm_group");
     }
 
-    /// Get the wrapped @p MPI_Group object.
+    /// Get the wrapped `MPI_Group` object.
     [[nodiscard]] MPI_Group get() const noexcept { return grp_; }
 
-    /// Check if the contained @p MPI_Group is @p MPI_GROUP_NULL.
+    /// Check if the contained `MPI_Group` is `MPI_GROUP_NULL`.
     [[nodiscard]] bool is_null() const noexcept { return grp_ == MPI_GROUP_NULL; }
 
-    /// Rank of the calling process in the given group.
+    /**
+     * @brief Get the rank of the calling process in the group.
+     * @return The result of `MPI_Group_rank` if mpi::has_env is true, otherwise 0.
+     */
     [[nodiscard]] int rank() const {
       int r = 0;
       if (has_env) check_mpi_call(MPI_Group_rank(grp_, &r), "MPI_Group_rank");
       return r;
     }
 
-    /// Size of a group.
+    /**
+     * @brief Get the size of the communicator.
+     * @return The result of `MPI_Comm_size` if mpi::has_env is true, otherwise 1.
+     */
     [[nodiscard]] int size() const {
       int s = 1;
       if (has_env) check_mpi_call(MPI_Group_size(grp_, &s), "MPI_Group_size");
@@ -99,7 +108,10 @@ namespace mpi {
     }
 
     /**
-     * @brief Produces a group by reordering an existing group and taking only listed members.
+     * @brief Create a new group by calling `MPI_Group_incl`.
+     *
+     * @details It produces a new group by reordering the existing group and taking only listed members.
+     *
      * @param ranks List of ranks to include in the new group.
      * @return New group containing only the listed members.
      */
@@ -109,7 +121,7 @@ namespace mpi {
       return group{newgroup};
     }
 
-    /// Free the group.
+    /// Free the group by calling `MPI_Group_free` (if it is not is_null()).
     void free() noexcept {
       if (has_env && !is_null()) MPI_Group_free(&grp_);
     }

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -335,79 +335,23 @@ namespace mpi {
       }
     }
 
-    /**
-    * @brief Retrieves the value of a window attribute.
-    *
-    * @details This function queries an attribute associated with an MPI window.
-    *
-    * @param win_keyval The key identifying the attribute.
-    * @return A pointer to the attribute value.
-    */
-    void *get_attr(int win_keyval) const noexcept {
-      if (has_env) {
-        int flag;
-        void *attribute_val;
-        MPI_Win_get_attr(win_, win_keyval, &attribute_val, &flag);
-        ASSERT(flag)
-        return attribute_val;
-      } else {
-        ASSERT(has_env)
-        return nullptr;
-      }
-    }
+    /// Get a pointer to the beginning of the window memory.
+    [[nodiscard]] BaseType *base() const { return data_; }
 
-    /**
-    * @brief Retrieves the base address of the memory window.
-    *
-    * @details This function returns a pointer to the base address of the memory associated with the MPI window.
-    *
-    * @return A pointer to the base address of the window memory.
-    */
-    BaseType *base() const noexcept {
-      if (has_env) {
-        if (win_ == MPI_WIN_NULL) { return nullptr; }
-        return static_cast<BaseType *>(get_attr(MPI_WIN_BASE));
-      } else {
-        return data_;
-      }
-    }
+    /// Get the size of the window in bytes.
+    [[nodiscard]] MPI_Aint size() const { return size_ * sizeof(BaseType); }
 
-    /**
-    * @brief Retrieves the size of the memory window.
-    *
-    * @details This function returns the total size (in bytes) of the memory associated with the MPI window.
-    *
-    * @return The size of the MPI window in bytes.
-    */
+    /// Get the displacement unit in bytes.
+    [[nodiscard]] int disp_unit() const { return sizeof(BaseType); }
 
-    MPI_Aint size() const noexcept {
-      if (has_env) {
-        return *static_cast<MPI_Aint *>(get_attr(MPI_WIN_SIZE));
-      } else {
-        return size_ * sizeof(BaseType);
-      }
-    }
+    /// Get a pointer to the beginning of the window memory.
+    [[nodiscard]] BaseType *data() noexcept { return data_; }
 
-    /**
-    * @brief Retrieves the displacement unit of the memory window.
-    *
-    * @details The displacement unit determines the scaling factor for address displacements.
-    *
-    * @return The displacement unit (in bytes).
-    */
+    /// Get a pointer to the beginning of the window memory.
+    [[nodiscard]] BaseType *data() const noexcept { return data_; }
 
-    int disp_unit() const noexcept {
-      if (has_env) {
-        return *static_cast<int *>(get_attr(MPI_WIN_DISP_UNIT));
-      } else {
-        return sizeof(BaseType);
-      }
-    }
-
-    BaseType *&data() noexcept { return data_; }
-    BaseType &data() const noexcept { return data_; }
-
-    communicator get_communicator() noexcept { return comm_.get(); }
+    /// Get the mpi::communicator associated with the window.
+    [[nodiscard]] communicator get_communicator() const { return comm_.get(); }
 
     protected:
     MPI_Win win_{MPI_WIN_NULL};

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -53,29 +53,24 @@ namespace mpi {
 
   template <class BaseType> class window {
     friend class shared_window<BaseType>;
-    MPI_Win _win{MPI_WIN_NULL};
-    communicator _comm{MPI_COMM_NULL};
-    bool _owned{true};
-    BaseType *_data{nullptr};
-    MPI_Aint _size{0};
 
     public:
     window()               = default;
     window(window const &) = delete;
     window(window &&other) noexcept
-       : _win{std::exchange(other._win, MPI_WIN_NULL)},
-         _owned{std::exchange(other._owned, true)},
-         _data{std::exchange(other._data, nullptr)},
-         _size{std::exchange(other._size, 0)} {}
+       : win_{std::exchange(other.win_, MPI_WIN_NULL)},
+         owned_{std::exchange(other.owned_, true)},
+         data_{std::exchange(other.data_, nullptr)},
+         size_{std::exchange(other.size_, 0)} {}
     window &operator=(window const &) = delete;
     window &operator=(window &&rhs) noexcept {
       if (this != std::addressof(rhs)) {
         this->free();
-        this->_win   = std::exchange(rhs._win, MPI_WIN_NULL);
-        this->_comm  = std::exchange(rhs._comm, communicator(MPI_COMM_NULL));
-        this->_owned = std::exchange(rhs._owned, true);
-        this->_data  = std::exchange(rhs._data, nullptr);
-        this->_size  = std::exchange(rhs._size, 0);
+        this->win_   = std::exchange(rhs.win_, MPI_WIN_NULL);
+        this->comm_  = std::exchange(rhs.comm_, communicator(MPI_COMM_NULL));
+        this->owned_ = std::exchange(rhs.owned_, true);
+        this->data_  = std::exchange(rhs.data_, nullptr);
+        this->size_  = std::exchange(rhs.size_, 0);
       }
       return *this;
     }
@@ -92,17 +87,17 @@ namespace mpi {
     * @param size The number of elements of type @p BaseType in the buffer. (default @p 0)
     * @param info Additional MPI information. (default @p MPI_INFO_NULL)
     */
-    explicit window(communicator const &c, BaseType *base, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept(false) : _comm(c.get()) {
+    explicit window(communicator const &c, BaseType *base, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept(false) : comm_(c.get()) {
       ASSERT(size >= 0)
       ASSERT(!(base == nullptr && size > 0))
       if (has_env) {
-        MPI_Win_create(base, size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &_win);
-        _data = base;
-        _size = size;
+        MPI_Win_create(base, size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &win_);
+        data_ = base;
+        size_ = size;
       } else {
-        _owned = false;
-        _data  = base;
-        _size  = size;
+        owned_ = false;
+        data_  = base;
+        size_  = size;
       }
     }
 
@@ -118,17 +113,17 @@ namespace mpi {
     * @param size The number of elements of type @p BaseType to allocate. (default @p 0)
     * @param info Additional MPI information. (default @p MPI_INFO_NULL)
     */
-    explicit window(communicator const &c, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept : _comm(c.get()) {
+    explicit window(communicator const &c, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept : comm_(c.get()) {
       ASSERT(size >= 0)
       if (has_env) {
         void *baseptr = nullptr;
-        MPI_Win_allocate(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &_win);
-        _data = static_cast<BaseType *>(baseptr);
-        _size = size;
+        MPI_Win_allocate(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &win_);
+        data_ = static_cast<BaseType *>(baseptr);
+        size_ = size;
       } else {
-        _owned = true;
-        _data  = new BaseType[size];
-        _size  = size;
+        owned_ = true;
+        data_  = new BaseType[size];
+        size_  = size;
       }
     }
 
@@ -146,19 +141,19 @@ namespace mpi {
     */
     virtual ~window() { free(); }
 
-    explicit operator MPI_Win() const noexcept { return _win; };
-    explicit operator MPI_Win *() noexcept { return &_win; };
+    explicit operator MPI_Win() const noexcept { return win_; };
+    explicit operator MPI_Win *() noexcept { return &win_; };
 
     void free() noexcept {
       if (has_env) {
-        if (_win != MPI_WIN_NULL) {
+        if (win_ != MPI_WIN_NULL) {
           this->fence();
-          MPI_Win_free(&_win);
+          MPI_Win_free(&win_);
         }
       } else {
-        if (_owned) { delete[] _data; }
-        _data = nullptr;
-        _size = 0;
+        if (owned_) { delete[] data_; }
+        data_ = nullptr;
+        size_ = 0;
       }
     }
 
@@ -173,7 +168,7 @@ namespace mpi {
     * @param assert program assertion.
     */
     void fence(int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_fence(assert, _win); }
+      if (has_env) { MPI_Win_fence(assert, win_); }
     }
 
     /**
@@ -187,9 +182,9 @@ namespace mpi {
     void flush(int rank = -1) const noexcept {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_flush_all(_win);
+          MPI_Win_flush_all(win_);
         } else {
-          MPI_Win_flush(rank, _win);
+          MPI_Win_flush(rank, win_);
         }
       }
     }
@@ -201,7 +196,7 @@ namespace mpi {
     *          and vice versa.
     */
     void sync() const noexcept {
-      if (has_env) { MPI_Win_sync(_win); }
+      if (has_env) { MPI_Win_sync(win_); }
     }
 
     /**
@@ -217,9 +212,9 @@ namespace mpi {
     void lock(int rank = -1, int lock_type = MPI_LOCK_SHARED, int assert = 0) const noexcept {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_lock_all(assert, _win);
+          MPI_Win_lock_all(assert, win_);
         } else {
-          MPI_Win_lock(lock_type, rank, assert, _win);
+          MPI_Win_lock(lock_type, rank, assert, win_);
         }
       }
     }
@@ -237,9 +232,9 @@ namespace mpi {
     void unlock(int rank = -1) const noexcept {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_unlock_all(_win);
+          MPI_Win_unlock_all(win_);
         } else {
-          MPI_Win_unlock(rank, _win);
+          MPI_Win_unlock(rank, win_);
         }
       }
     }
@@ -251,14 +246,14 @@ namespace mpi {
     * @param assert An assertion flag providing optimization hints to MPI.
     */
     void start(group const &grp, int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_start(grp.get(), assert, _win); }
+      if (has_env) { MPI_Win_start(grp.get(), assert, win_); }
     }
 
     /**
     * @brief Completes an RMA access epoch on win started by a call to @p start.
     */
     void complete() const noexcept {
-      if (has_env) { MPI_Win_complete(_win); }
+      if (has_env) { MPI_Win_complete(win_); }
     }
 
     /**
@@ -268,14 +263,14 @@ namespace mpi {
     * @param assert An assertion flag providing optimization hints to MPI.
     */
     void post(group const &grp, int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_post(grp.get(), assert, _win); }
+      if (has_env) { MPI_Win_post(grp.get(), assert, win_); }
     }
 
     /**
     * @brief Completes an RMA exposure epoch started by a call to @p post.
     */
     void wait() const noexcept {
-      if (has_env) { MPI_Win_wait(_win); }
+      if (has_env) { MPI_Win_wait(win_); }
     }
 
     /**
@@ -299,12 +294,12 @@ namespace mpi {
       if (has_env) {
         MPI_Datatype origin_datatype = mpi_type<OriginType>::get();
         MPI_Datatype target_datatype = mpi_type<TargetType>::get();
-        MPI_Get(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, _win);
+        MPI_Get(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, win_);
       } else {
         if (target_rank != 0) { return; }
 
         std::span<OriginType> origin(origin_addr, origin_count);
-        BaseType *target_begin = _data;
+        BaseType *target_begin = data_;
         std::advance(target_begin, target_disp);
         BaseType *target_end = target_begin;
         std::advance(target_end, target_count_);
@@ -333,12 +328,12 @@ namespace mpi {
       if (has_env) {
         MPI_Datatype origin_datatype = mpi_type<OriginType>::get();
         MPI_Datatype target_datatype = mpi_type<TargetType>::get();
-        MPI_Put(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, _win);
+        MPI_Put(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, win_);
       } else {
         if (target_rank != 0) { return; }
 
         std::span<OriginType> origin(origin_addr, origin_count);
-        BaseType *target_begin = _data;
+        BaseType *target_begin = data_;
         std::advance(target_begin, target_disp);
         std::copy(origin.begin(), origin.end(), target_begin);
       }
@@ -356,7 +351,7 @@ namespace mpi {
       if (has_env) {
         int flag;
         void *attribute_val;
-        MPI_Win_get_attr(_win, win_keyval, &attribute_val, &flag);
+        MPI_Win_get_attr(win_, win_keyval, &attribute_val, &flag);
         ASSERT(flag)
         return attribute_val;
       } else {
@@ -374,10 +369,10 @@ namespace mpi {
     */
     BaseType *base() const noexcept {
       if (has_env) {
-        if (_win == MPI_WIN_NULL) { return nullptr; }
+        if (win_ == MPI_WIN_NULL) { return nullptr; }
         return static_cast<BaseType *>(get_attr(MPI_WIN_BASE));
       } else {
-        return _data;
+        return data_;
       }
     }
 
@@ -393,7 +388,7 @@ namespace mpi {
       if (has_env) {
         return *static_cast<MPI_Aint *>(get_attr(MPI_WIN_SIZE));
       } else {
-        return _size * sizeof(BaseType);
+        return size_ * sizeof(BaseType);
       }
     }
 
@@ -413,10 +408,17 @@ namespace mpi {
       }
     }
 
-    BaseType *&data() noexcept { return _data; }
-    BaseType &data() const noexcept { return _data; }
+    BaseType *&data() noexcept { return data_; }
+    BaseType &data() const noexcept { return data_; }
 
-    communicator get_communicator() noexcept { return _comm.get(); }
+    communicator get_communicator() noexcept { return comm_.get(); }
+
+    protected:
+    MPI_Win win_{MPI_WIN_NULL};
+    communicator comm_{MPI_COMM_NULL};
+    bool owned_{true};
+    BaseType *data_{nullptr};
+    MPI_Aint size_{0};
   };
 
   /**
@@ -444,15 +446,15 @@ namespace mpi {
       ASSERT(size >= 0)
       if (has_env) {
         void *baseptr = nullptr;
-        MPI_Win_allocate_shared(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &(this->_win));
-        this->_comm = c.get();
-        this->_data = static_cast<BaseType *>(baseptr);
-        this->_size = size;
+        MPI_Win_allocate_shared(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &(this->win_));
+        this->comm_ = c.get();
+        this->data_ = static_cast<BaseType *>(baseptr);
+        this->size_ = size;
       } else {
-        this->_owned = true;
-        this->_comm  = c.get();
-        this->_data  = new BaseType[size];
-        this->_size  = size;
+        this->owned_ = true;
+        this->comm_  = c.get();
+        this->data_  = new BaseType[size];
+        this->size_  = size;
       }
     }
 
@@ -469,10 +471,10 @@ namespace mpi {
         MPI_Aint size = 0;
         int disp_unit = 0;
         void *baseptr = nullptr;
-        MPI_Win_shared_query(this->_win, rank, &size, &disp_unit, &baseptr);
+        MPI_Win_shared_query(this->win_, rank, &size, &disp_unit, &baseptr);
         return {size, disp_unit, baseptr};
       } else {
-        return {this->_size * sizeof(BaseType), sizeof(BaseType), this->_data};
+        return {this->size_ * sizeof(BaseType), sizeof(BaseType), this->data_};
       }
     }
 
@@ -502,7 +504,7 @@ namespace mpi {
      */
     int disp_unit(int rank = MPI_PROC_NULL) const noexcept { return std::get<1>(query(rank)); }
 
-    shared_communicator get_communicator() { return this->_comm.get(); }
+    shared_communicator get_communicator() { return this->comm_.get(); }
   };
 
   /** @} */

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -166,119 +166,115 @@ namespace mpi {
     }
 
     /**
-    * @brief Synchronizes all RMA operations within an access epoch.
-    *
-    * @details This function acts as a barrier for remote memory access (RMA)
-    *          operations, ensuring all previous operations on the window are
-    *          completed before continuing.  The call is collective on the group
-    *          of the window.
-    *
-    * @param assert program assertion.
-    */
-    void fence(int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_fence(assert, win_); }
+     * @brief Synchronize all RMA operations within an access epoch by calling `MPI_Win_fence`.
+     *
+     * @details This function acts as a barrier for remote memory access (RMA) operations, ensuring all previous
+     * operations on the window are completed before continuing. The call is collective on the group of the window.
+     *
+     * @param assert Program assertion.
+     */
+    void fence(int assert = 0) const {
+      if (has_env) check_mpi_call(MPI_Win_fence(assert, win_), "MPI_Win_fence");
     }
 
     /**
-    * @brief Ensures completion of all outstanding RMA operations.
-    *
-    * @details This function forces all RMA operations issued to a specific rank (or all ranks)
-    *          to complete at both the origin and the target before proceeding.
-    *
-    * @param rank The rank to flush operations for. If negative or no rank is specified, flushes all ranks .
-    */
-    void flush(int rank = -1) const noexcept {
+     * @brief Ensure completion of all outstanding RMA operations.
+     *
+     * @details If the given target rank is \f$ < 0 \f$, it calls `MPI_Win_flush_all`. Otherwise, it calls
+     * `MPI_Win_flush`.
+     *
+     * @param rank Target rank.
+     */
+    void flush(int rank = -1) const {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_flush_all(win_);
+          check_mpi_call(MPI_Win_flush_all(win_), "MPI_Win_flush_all");
         } else {
-          MPI_Win_flush(rank, win_);
+          check_mpi_call(MPI_Win_flush(rank, win_), "MPI_Win_flush");
         }
       }
     }
 
     /**
-    * @brief Synchronizes the public and private copies of the window.
-    *
-    * @details Ensures that any updates to the local memory are visible in the public window
-    *          and vice versa.
-    */
-    void sync() const noexcept {
-      if (has_env) { MPI_Win_sync(win_); }
+     * @brief Synchronize the public and private copies of the window.
+     *
+     * @details It ensures that any updates to the local memory are visible in the public window and vice versa by
+     * calling `MPI_Win_sync`.
+     */
+    void sync() const {
+      if (has_env) check_mpi_call(MPI_Win_sync(win_), "MPI_Win_sync");
     }
 
     /**
-    * @brief Starts an RMA access epoch.
-    *
-    * @details Locks access to the memory window for a specific rank or all ranks,
-    *          preventing concurrent modifications.
-    *
-    * @param rank The rank to lock access for.
-    * @param lock_type The type of lock (e.g., @p MPI_LOCK_SHARED or @p MPI_LOCK_EXCLUSIVE).
-    * @param assert An assertion flag providing optimization hints to MPI.
-    */
-    void lock(int rank = -1, int lock_type = MPI_LOCK_SHARED, int assert = 0) const noexcept {
+     * @brief Start an RMA access epoch.
+     *
+     * @details It locks access to the memory window on a specific rank or all ranks, preventing concurrent
+     * modifications.
+     *
+     * If the given target rank is \f$ < 0 \f$, it calls `MPI_Win_lock_all`. Otherwise, it calls `MPI_Win_lock`.
+     *
+     * @param rank Target rank.
+     * @param lock_type Type of the lock (e.g. `MPI_LOCK_SHARED` or `MPI_LOCK_EXCLUSIVE`).
+     * @param assert An assertion flag providing optimization hints to MPI.
+     */
+    void lock(int rank = -1, int lock_type = MPI_LOCK_SHARED, int assert = 0) const {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_lock_all(assert, win_);
+          check_mpi_call(MPI_Win_lock_all(assert, win_), "MPI_Win_lock_all");
         } else {
-          MPI_Win_lock(lock_type, rank, assert, win_);
+          check_mpi_call(MPI_Win_lock(lock_type, rank, assert, win_), "MPI_Win_lock");
         }
       }
     }
 
     /**
-    * @brief Completes an RMA access epoch started by @p lock().
-    *
-    * @details Unlocks access to the memory window for a specific rank or all ranks,
-    *          allowing other processes to access or modify the window.
-    *
-    * @see lock
-    *
-    * @param rank The rank to unlock access for.
-    */
-    void unlock(int rank = -1) const noexcept {
+     * @brief Complete an RMA access epoch started by lock().
+     *
+     * @details It unlocks access to the memory window on a specific rank or all ranks, allowing other processes to
+     * access or modify the window.
+     *
+     * If the given target rank is \f$ < 0 \f$, it calls `MPI_Win_unlock_all`. Otherwise, it calls `MPI_Win_unlock`.
+     *
+     * @param rank Target rank.
+     */
+    void unlock(int rank = -1) const {
       if (has_env) {
         if (rank < 0) {
-          MPI_Win_unlock_all(win_);
+          check_mpi_call(MPI_Win_unlock_all(win_), "MPI_Win_unlock_all");
         } else {
-          MPI_Win_unlock(rank, win_);
+          check_mpi_call(MPI_Win_unlock(rank, win_), "MPI_Win_unlock");
         }
       }
     }
 
     /**
-    * @brief Starts an RMA access epoch.
-    *
-    * @param grp The group of target processes.
-    * @param assert An assertion flag providing optimization hints to MPI.
-    */
-    void start(group const &grp, int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_start(grp.get(), assert, win_); }
+     * @brief Start an RMA access epoch by calling `MPI_Win_start` (see also complete()).
+     *
+     * @param grp mpi::group of target processes.
+     * @param assert An assertion flag providing optimization hints to MPI.
+     */
+    void start(group const &grp, int assert = 0) const {
+      if (has_env) check_mpi_call(MPI_Win_start(grp.get(), assert, win_), "MPI_Win_start");
+    }
+
+    /// Completes an RMA access epoch by calling `MPI_Win_complete` (see also start()).
+    void complete() const {
+      if (has_env) check_mpi_call(MPI_Win_complete(win_), "MPI_Win_complete");
     }
 
     /**
-    * @brief Completes an RMA access epoch on win started by a call to @p start.
-    */
-    void complete() const noexcept {
-      if (has_env) { MPI_Win_complete(win_); }
+     * @brief Start an RMA exposure epoch by calling `MPI_Win_post` (see also wait()).
+     *
+     * @param grp mpi::group of origin processes.
+     * @param assert An assertion flag providing optimization hints to MPI.
+     */
+    void post(group const &grp, int assert = 0) const {
+      if (has_env) check_mpi_call(MPI_Win_post(grp.get(), assert, win_), "MPI_Win_post");
     }
 
-    /**
-    * @brief Starts an RMA exposure epoch for the local window.
-    *
-    * @param grp The group of origin processes.
-    * @param assert An assertion flag providing optimization hints to MPI.
-    */
-    void post(group const &grp, int assert = 0) const noexcept {
-      if (has_env) { MPI_Win_post(grp.get(), assert, win_); }
-    }
-
-    /**
-    * @brief Completes an RMA exposure epoch started by a call to @p post.
-    */
-    void wait() const noexcept {
-      if (has_env) { MPI_Win_wait(win_); }
+    /// Completes an RMA exposure epoch by calling `MPI_Win_wait` (see also post()).
+    void wait() const {
+      if (has_env) check_mpi_call(MPI_Win_wait(win_), "MPI_Win_wait");
     }
 
     /**

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -344,12 +344,6 @@ namespace mpi {
     /// Get the displacement unit in bytes.
     [[nodiscard]] int disp_unit() const { return sizeof(BaseType); }
 
-    /// Get a pointer to the beginning of the window memory.
-    [[nodiscard]] BaseType *data() noexcept { return data_; }
-
-    /// Get a pointer to the beginning of the window memory.
-    [[nodiscard]] BaseType *data() const noexcept { return data_; }
-
     /// Get the mpi::communicator associated with the window.
     [[nodiscard]] communicator get_communicator() const { return comm_.get(); }
 

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -16,7 +16,7 @@
 
 /**
  * @file
- * @brief Provides a C++ wrapper class for the @p MPI_Win object.
+ * @brief Provides a C++ wrapper class for an `MPI_Win` object.
  */
 
 #pragma once
@@ -25,9 +25,13 @@
 #include "./datatypes.hpp"
 #include "./group.hpp"
 #include "./macros.hpp"
+#include "./utils.hpp"
 
 #include <mpi.h>
 
+#include <algorithm>
+#include <memory>
+#include <tuple>
 #include <utility>
 
 namespace mpi {
@@ -37,124 +41,128 @@ namespace mpi {
    * @{
    */
 
+  // Forward declaration.
   template <class BaseType> class shared_window;
 
   /**
-  * @brief A C++ wrapper around @p MPI_Win providing convenient memory window management.
-  *
-  * @details This class abstracts the complexities of MPI window management, allowing processes
-  *          in an MPI communicator to create and share memory regions efficiently. It supports
-  *          both local buffer-based windows and dynamically allocated memory windows.
-  *
-  *          If a base pointer is not specified, the constructor will allocate memory internally.
-  *
-  * @tparam BaseType The type of elements stored in the memory window.
-  */
-
+   * @brief A C++ wrapper around `MPI_Win` providing convenient memory window management.
+   *
+   * @details This class abstracts the complexities of MPI window management, allowing processes in an MPI communicator
+   * to create and share memory regions efficiently. It supports both local buffer-based windows and dynamically
+   * allocated memory windows.
+   *
+   * If a base pointer is not specified, the constructor will allocate memory internally.
+   *
+   * @tparam BaseType The type of elements stored in the memory window.
+   */
   template <class BaseType> class window {
-    friend class shared_window<BaseType>;
-
     public:
-    window()               = default;
+    /// Type of the base pointer.
+    using base_type = BaseType;
+
+    /// Construct a window with `MPI_WIN_NULL`.
+    window() = default;
+
+    /// Deleted copy constructor.
     window(window const &) = delete;
+
+    /// Deleted copy assignment operator.
+    window &operator=(window const &) = delete;
+
+    /// Move constructor takes ownership of the moved-from MPI window and leaves it with `MPI_WIN_NULL`.
     window(window &&other) noexcept
        : win_{std::exchange(other.win_, MPI_WIN_NULL)},
-         owned_{std::exchange(other.owned_, true)},
+         comm_{std::exchange(other.comm_, communicator{MPI_COMM_NULL})},
+         owned_{std::exchange(other.owned_, false)},
          data_{std::exchange(other.data_, nullptr)},
          size_{std::exchange(other.size_, 0)} {}
-    window &operator=(window const &) = delete;
+
+    /// Move assignment operator takes ownership of the moved-from MPI window and leaves it with `MPI_WIN_NULL`.
     window &operator=(window &&rhs) noexcept {
       if (this != std::addressof(rhs)) {
-        this->free();
-        this->win_   = std::exchange(rhs.win_, MPI_WIN_NULL);
-        this->comm_  = std::exchange(rhs.comm_, communicator(MPI_COMM_NULL));
-        this->owned_ = std::exchange(rhs.owned_, true);
-        this->data_  = std::exchange(rhs.data_, nullptr);
-        this->size_  = std::exchange(rhs.size_, 0);
+        free();
+        win_   = std::exchange(rhs.win_, MPI_WIN_NULL);
+        comm_  = std::exchange(rhs.comm_, communicator{MPI_COMM_NULL});
+        owned_ = std::exchange(rhs.owned_, false);
+        data_  = std::exchange(rhs.data_, nullptr);
+        size_  = std::exchange(rhs.size_, 0);
       }
       return *this;
     }
 
     /**
-    * @brief Constructs an MPI window over an existing local memory buffer.
-    *
-    * @details This constructor allows creating a window using a pre-allocated memory buffer.
-    *          The window provides access to the specified memory region across MPI processes
-    *          within the given communicator. The buffer is not freed upon destruction.
-    *
-    * @param c The MPI communicator that defines the group of processes sharing the window.
-    * @param base Pointer to the base address of the memory buffer.
-    * @param size The number of elements of type @p BaseType in the buffer. (default @p 0)
-    * @param info Additional MPI information. (default @p MPI_INFO_NULL)
-    */
-    explicit window(communicator const &c, BaseType *base, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept(false) : comm_(c.get()) {
-      ASSERT(size >= 0)
-      ASSERT(!(base == nullptr && size > 0))
-      if (has_env) {
-        MPI_Win_create(base, size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &win_);
-        data_ = base;
-        size_ = size;
-      } else {
-        owned_ = false;
-        data_  = base;
-        size_  = size;
-      }
+     * @brief Construct an MPI window over an existing local memory buffer.
+     *
+     * @details This constructor allows creating a window using a pre-allocated memory buffer by calling
+     * `MPI_Win_create`. The window provides access to the specified memory region across MPI processes within the given
+     * communicator. The buffer is not freed upon destruction.
+     *
+     * @param c mpi::communicator that defines the group of processes sharing the window.
+     * @param base_ptr Pointer to the base address of the memory buffer.
+     * @param sz Number of elements in the buffer.
+     * @param info Additional MPI information. Default is `MPI_INFO_NULL`.
+     */
+    explicit window(communicator const &c, BaseType *base_ptr, MPI_Aint sz, MPI_Info info = MPI_INFO_NULL)
+       : comm_(c.get()), data_(base_ptr), size_(sz) {
+      ASSERT(size_ >= 0)
+      ASSERT(!(data_ == nullptr && size_ > 0))
+      if (has_env) check_mpi_call(MPI_Win_create(data_, size_ * sizeof(BaseType), sizeof(BaseType), info, c.get(), &win_), "MPI_Win_create");
     }
 
     /**
-    * @brief Constructs an MPI window with dynamically allocated memory.
-    *
-    * @details This constructor allocates a new memory buffer locally and creates an MPI window
-    *          over it. The allocated memory is automatically freed when the window is destroyed.
-    *          This is useful when the memory region is meant to be shared across processes
-    *          without needing an external buffer.
-    *
-    * @param c The MPI communicator that defines the group of processes sharing the window.
-    * @param size The number of elements of type @p BaseType to allocate. (default @p 0)
-    * @param info Additional MPI information. (default @p MPI_INFO_NULL)
-    */
-    explicit window(communicator const &c, MPI_Aint size = 0, MPI_Info info = MPI_INFO_NULL) noexcept : comm_(c.get()) {
-      ASSERT(size >= 0)
+     * @brief Construct an MPI window with dynamically allocated memory.
+     *
+     * @details This constructor allocates a new memory buffer locally and creates an MPI window over it by calling
+     * `MPI_Win_allocate`. The allocated memory is automatically freed when the window is destroyed. This is useful when
+     * the memory region is meant to be shared across processes without needing an external buffer.
+     *
+     * @param c mpi::communicator that defines the group of processes sharing the window.
+     * @param sz Number of elements to allocate for the calling process.
+     * @param info Additional MPI information. Default is `MPI_INFO_NULL`.
+     */
+    explicit window(communicator const &c, MPI_Aint sz, MPI_Info info = MPI_INFO_NULL) : comm_(c.get()), size_(sz) {
+      ASSERT(size_ >= 0)
       if (has_env) {
-        void *baseptr = nullptr;
-        MPI_Win_allocate(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &win_);
-        data_ = static_cast<BaseType *>(baseptr);
-        size_ = size;
+        check_mpi_call(MPI_Win_allocate(size_ * sizeof(BaseType), sizeof(BaseType), info, c.get(), &data_, &win_), "MPI_Win_allocate");
       } else {
         owned_ = true;
-        data_  = new BaseType[size];
-        size_  = size;
+        data_  = new BaseType[size_]; // NOLINT (new is fine here)
       }
     }
 
-    /**
-    * @brief Destroys the window and releases allocated resources.
-    *
-    * Before freeing, a window must have completed all its involvement in RMA
-    * communications.  For that reason the destructor implicitly calls @p
-    * fence().  The window also must be unlocked if it has been previously
-    * locked, however, this cannot be detected and is therefore the
-    * responsibility of the caller.
-    *
-    * @details If the window owns an allocated memory buffer, it will be automatically freed.
-    *          Otherwise, only the MPI window handle is released.
-    */
+    /// Convert the window to the wrapped `MPI_Win` object.
+    explicit operator MPI_Win() const { return win_; };
+
+    /// Convert a pointer to the window to a pointer to the wrapped `MPI_Win` object.
+    explicit operator MPI_Win *() { return &win_; };
+
+    /// Destructor calls free() to release the window.
     virtual ~window() { free(); }
 
-    explicit operator MPI_Win() const noexcept { return win_; };
-    explicit operator MPI_Win *() noexcept { return &win_; };
-
+    /**
+     * @brief Release allocated resources owned by the window.
+     *
+     * @details Before freeing the owned memory or the `MPI_Win` handle, a window must have completed all its
+     * involvement in RMA communications. For that reason we call fence() before `MPI_Win_free`.
+     *
+     * The window also must be unlocked if it has been previously locked. However, this cannot be detected and is
+     * therefore the responsibility of the user.
+     *
+     * If the window owns an allocated memory buffer, it will be automatically freed. Otherwise, only the MPI window
+     * handle is released.
+     */
     void free() noexcept {
       if (has_env) {
         if (win_ != MPI_WIN_NULL) {
-          this->fence();
+          fence();
           MPI_Win_free(&win_);
         }
-      } else {
-        if (owned_) { delete[] data_; }
-        data_ = nullptr;
-        size_ = 0;
+      } else if (owned_) {
+        delete[] data_;
       }
+      owned_ = false;
+      data_  = nullptr;
+      size_  = 0;
     }
 
     /**
@@ -416,7 +424,7 @@ namespace mpi {
     protected:
     MPI_Win win_{MPI_WIN_NULL};
     communicator comm_{MPI_COMM_NULL};
-    bool owned_{true};
+    bool owned_{false};
     BaseType *data_{nullptr};
     MPI_Aint size_{0};
   };

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -278,68 +278,60 @@ namespace mpi {
     }
 
     /**
-    * @brief Reads data from a remote memory window.
-    *
-    * @details This function retrieves data from a remote process's memory
-    *          window and stores it in a local buffer.
-    *
-    * @tparam TargetType The data type at the target memory.
-    * @tparam OriginType The data type at the origin memory.
-    * @param origin_addr Pointer to the memory buffer where the data will be stored.
-    * @param origin_count Number of elements to retrieve.
-    * @param target_rank Rank of the target process from which data is fetched.
-    * @param target_disp Displacement (in @p disp_unit) from the start of the target memory window.
-    * @param target_count Number of elements to read from the target. If negative or not specified, defaults to @p origin_count.
-    */
+     * @brief Read data from a remote memory window.
+     *
+     * @details This function retrieves data from the memory window on the given process by calling `MPI_get` and stores
+     * it in a local buffer.
+     *
+     * @tparam TargetType Value type of the target memory.
+     * @tparam OriginType Value type of the origin memory.
+     * @param origin_addr Pointer to the memory buffer where the data will be stored.
+     * @param origin_count Number of elements to retrieve.
+     * @param target_rank Rank of the target process from which data is fetched.
+     * @param target_disp Displacement from the start of the target memory window.
+     * @param target_count Number of elements to read from the target. If negative or not specified, defaults to
+     * `origin_count`.
+     */
     template <typename TargetType = BaseType, typename OriginType>
       requires(has_mpi_type<OriginType> && has_mpi_type<TargetType>)
-    void get(OriginType *origin_addr, int origin_count, int target_rank, MPI_Aint target_disp = 0, int target_count = -1) const noexcept {
-      int target_count_ = target_count < 0 ? origin_count : target_count;
+    void get(OriginType *origin_addr, int origin_count, int target_rank, MPI_Aint target_disp = 0, int target_count = -1) const {
+      ASSERT(origin_count >= 0 && target_disp >= 0);
+      target_count = target_count < 0 ? origin_count : target_count;
       if (has_env) {
-        MPI_Datatype origin_datatype = mpi_type<OriginType>::get();
-        MPI_Datatype target_datatype = mpi_type<TargetType>::get();
-        MPI_Get(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, win_);
+        auto origin_datatype = mpi_type<OriginType>::get();
+        auto target_datatype = mpi_type<TargetType>::get();
+        check_mpi_call(MPI_Get(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win_), "MPI_Get");
       } else {
-        if (target_rank != 0) { return; }
-
-        std::span<OriginType> origin(origin_addr, origin_count);
-        BaseType *target_begin = data_;
-        std::advance(target_begin, target_disp);
-        BaseType *target_end = target_begin;
-        std::advance(target_end, target_count_);
-        std::copy(target_begin, target_end, origin.begin());
+        std::copy(data_, data_ + target_count, origin_addr);
       }
     }
 
     /**
-    * @brief Writes data to a remote memory window.
-    *
-    * @details This function transfers data from a local buffer to a remote process's
-    *          memory window.
-    *
-    * @tparam TargetType The data type at the target memory.
-    * @tparam OriginType The data type at the origin memory.
-    * @param origin_addr Pointer to the local memory buffer containing the data to be sent.
-    * @param origin_count Number of elements to transfer.
-    * @param target_rank Rank of the target process to which data is written.
-    * @param target_disp Displacement (in @p disp_unit) from the start of the target memory window.
-    * @param target_count Number of elements to write to the target. If negative or not specified, defaults to @p origin_count.
-    */
+     * @brief Write data to a remote memory window.
+     *
+     * @details This function transfers data from a local buffer to the memory window on the given process by calling
+     * `MPI_Put`.
+     *
+     * @tparam TargetType Value type at the target memory.
+     * @tparam OriginType Value type at the origin memory.
+     * @param origin_addr Pointer to the local memory buffer containing the data to be sent.
+     * @param origin_count Number of elements to transfer.
+     * @param target_rank Rank of the target process to which data is written.
+     * @param target_disp Displacement from the start of the target memory window.
+     * @param target_count Number of elements to write to the target. If negative or not specified, defaults to
+     * `origin_count`.
+     */
     template <typename TargetType = BaseType, typename OriginType>
       requires(has_mpi_type<OriginType> && has_mpi_type<TargetType>)
-    void put(OriginType *origin_addr, int origin_count, int target_rank, MPI_Aint target_disp = 0, int target_count = -1) const noexcept {
-      int target_count_ = target_count < 0 ? origin_count : target_count;
+    void put(OriginType *origin_addr, int origin_count, int target_rank, MPI_Aint target_disp = 0, int target_count = -1) const {
+      ASSERT(origin_count >= 0 && target_disp >= 0);
+      target_count = target_count < 0 ? origin_count : target_count;
       if (has_env) {
-        MPI_Datatype origin_datatype = mpi_type<OriginType>::get();
-        MPI_Datatype target_datatype = mpi_type<TargetType>::get();
-        MPI_Put(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count_, target_datatype, win_);
+        auto origin_datatype = mpi_type<OriginType>::get();
+        auto target_datatype = mpi_type<TargetType>::get();
+        check_mpi_call(MPI_Put(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win_), "MPI_Put");
       } else {
-        if (target_rank != 0) { return; }
-
-        std::span<OriginType> origin(origin_addr, origin_count);
-        BaseType *target_begin = data_;
-        std::advance(target_begin, target_disp);
-        std::copy(origin.begin(), origin.end(), target_begin);
+        std::copy(origin_addr, origin_addr + origin_count, data_);
       }
     }
 

--- a/c++/mpi/window.hpp
+++ b/c++/mpi/window.hpp
@@ -356,89 +356,93 @@ namespace mpi {
   };
 
   /**
-  * @brief A shared memory window abstraction using MPI.
-  *
-  * @details This class provides an interface for creating and managing an MPI shared memory window.
-  *
-  * @tparam BaseType The data type stored in the shared memory window.
-  */
+   * @brief A C++ wrapper around `MPI_Win` representing a shared memory window.
+   *
+   * @details This class provides an interface for creating and managing an MPI shared memory window.
+   *
+   * @tparam BaseType The type of elements stored in the shared memory window.
+   */
   template <class BaseType> class shared_window : public window<BaseType> {
     public:
-    /// Default constructor
+    ///Construct a shared memory window with `MPI_WIN_NULL`.
     shared_window() = default;
 
     /**
-     * @brief Constructs a shared memory window.
+     * @brief Construct a shared memory window by dynamically allocating memory.
      *
-     * @details This constructor allocates shared memory within the given communicator.
+     * @details This constructor allocates a shared memory window within the given communicator by calling
+     * `MPI_Win_allocate_shared`. The allocated memory is automatically freed when the window is destroyed.
      *
-     * @param c The shared communicator.
-     * @param size The number of elements of type @p BaseType to allocate.
-     * @param info MPI_Info object for optimization hints.
+     * @param c mpi::shared_communicator object.
+     * @param sz Number of elements to allocate for the calling process.
+     * @param info Additional MPI information.
      */
-    explicit shared_window(shared_communicator const &c, MPI_Aint size, MPI_Info info = MPI_INFO_NULL) noexcept {
-      ASSERT(size >= 0)
+    explicit shared_window(shared_communicator const &c, MPI_Aint sz, MPI_Info info = MPI_INFO_NULL) {
+      ASSERT(sz >= 0)
+      comm_ = c.get();
+      size_ = sz;
       if (has_env) {
-        void *baseptr = nullptr;
-        MPI_Win_allocate_shared(size * sizeof(BaseType), sizeof(BaseType), info, c.get(), &baseptr, &(this->win_));
-        this->comm_ = c.get();
-        this->data_ = static_cast<BaseType *>(baseptr);
-        this->size_ = size;
+        check_mpi_call(MPI_Win_allocate_shared(size_ * sizeof(BaseType), sizeof(BaseType), info, c.get(), &data_, &win_), "MPI_Win_allocate_shared");
       } else {
-        this->owned_ = true;
-        this->comm_  = c.get();
-        this->data_  = new BaseType[size];
-        this->size_  = size;
+        owned_ = true;
+        data_  = new BaseType[size_]; // NOLINT (new is fine here)
       }
     }
 
     /**
-     * @brief Queries attributes of a shared memory window.
+     * @brief Query attributes of a shared memory window.
      *
-     * @details Retrieves the size, displacement unit, and base address of the shared memory region for a given rank.
+     * @details Retrieves the size, displacement unit, and a pointer to the beginning of the shared memory region for a
+     * specific rank.
      *
-     * @param rank The rank within the communicator (defaults to @p MPI_PROC_NULL for querying all ranks).
-     * @return A tuple containing (size in bytes, displacement unit, base pointer).
+     * @param rank Rank within the shared communicator.
+     * @return A tuple containing the size in bytes, the displacement unit in bytes and the base pointer.
      */
-    std::tuple<MPI_Aint, int, void *> query(int rank = MPI_PROC_NULL) const noexcept {
+    [[nodiscard]] std::tuple<MPI_Aint, int, void *> query(int rank = MPI_PROC_NULL) const {
       if (has_env) {
-        MPI_Aint size = 0;
-        int disp_unit = 0;
+        MPI_Aint sz   = 0;
+        int du        = 0;
         void *baseptr = nullptr;
-        MPI_Win_shared_query(this->win_, rank, &size, &disp_unit, &baseptr);
-        return {size, disp_unit, baseptr};
+        check_mpi_call(MPI_Win_shared_query(win_, rank, &sz, &du, &baseptr), "MPI_Win_shared_query");
+        return {sz, du, baseptr};
       } else {
-        return {this->size_ * sizeof(BaseType), sizeof(BaseType), this->data_};
+        return {size_, sizeof(BaseType), data_};
       }
     }
 
-    // Override the commonly used attributes of the window base class
+    /**
+     * @brief Get a pointer to the beginning of the shared memory region of a specific rank.
+     *
+     * @param rank Rank within the shared communicator.
+     * @return Pointer to the shared window of the given rank.
+     */
+    [[nodiscard]] BaseType *base(int rank = MPI_PROC_NULL) const { return static_cast<BaseType *>(std::get<2>(query(rank))); }
 
     /**
-     * @brief Returns the base address of the shared memory for a specific rank.
+     * @brief Get the size of the shared memory region of a specific rank.
      *
-     * @param rank The rank whose base address should be retrieved.
-     * @return A pointer to the base address.
+     * @param rank Rank within the shared communicator.
+     * @return Number of elements in the shared window of the given rank.
      */
-    BaseType *base(int rank = MPI_PROC_NULL) const noexcept { return static_cast<BaseType *>(std::get<2>(query(rank))); }
+    [[nodiscard]] MPI_Aint size(int rank = MPI_PROC_NULL) const { return std::get<0>(query(rank)) / sizeof(BaseType); }
 
     /**
-     * @brief Returns the number of elements stored in the shared memory window.
+     * @brief Get the displacement unit of the shared memory region of a specific rank.
      *
-     * @param rank The rank whose memory size should be retrieved.
-     * @return The number of elements in the shared window.
+     * @param rank Rank within the shared communicator.
+     * @return Displacement unit in bytes.
      */
-    MPI_Aint size(int rank = MPI_PROC_NULL) const noexcept { return std::get<0>(query(rank)) / sizeof(BaseType); }
+    [[nodiscard]] int disp_unit(int rank = MPI_PROC_NULL) const { return std::get<1>(query(rank)); }
 
-    /**
-     * @brief Returns the displacement unit of the shared memory.
-     *
-     * @param rank The rank whose displacement unit should be retrieved.
-     * @return The displacement unit.
-     */
-    int disp_unit(int rank = MPI_PROC_NULL) const noexcept { return std::get<1>(query(rank)); }
+    /// Get the mpi::shared_communicator associated with the window.
+    [[nodiscard]] shared_communicator get_communicator() const { return comm_.get(); }
 
-    shared_communicator get_communicator() { return this->comm_.get(); }
+    private:
+    using window<BaseType>::win_;
+    using window<BaseType>::comm_;
+    using window<BaseType>::owned_;
+    using window<BaseType>::data_;
+    using window<BaseType>::size_;
   };
 
   /** @} */

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -249,7 +249,7 @@ PYTHON_DOCSTRING       = YES
 # documentation from any documented member that it re-implements.
 # The default value is: YES.
 
-INHERIT_DOCS           = YES
+INHERIT_DOCS           = NO
 
 # If the SEPARATE_MEMBER_PAGES tag is set to YES then doxygen will produce a new
 # page for each member. If set to NO, the documentation of a member will be part

--- a/test/c++/mpi_communicator.cpp
+++ b/test/c++/mpi_communicator.cpp
@@ -19,7 +19,26 @@
 
 #include <array>
 
-TEST(MPI, CommunicatorSplit) {
+TEST(MPI, CommunicatorDuplicateWorld) {
+  mpi::communicator world;
+
+  // skit the rest of test if there is no active MPI runtime
+  if (!mpi::has_env) return;
+
+  // duplicate and check the communicator
+  auto dup = world.duplicate();
+  EXPECT_EQ(world.rank(), dup.rank());
+  EXPECT_EQ(world.size(), dup.size());
+  EXPECT_EQ(MPI_COMM_WORLD, world.get());
+  EXPECT_NE(world.get(), dup.get());
+
+  // free the communicator
+  EXPECT_FALSE(dup.is_null());
+  dup.free();
+  EXPECT_TRUE(dup.is_null());
+}
+
+TEST(MPI, CommunicatorSplitAndDuplicate) {
   mpi::communicator world;
   int rank = world.rank();
 
@@ -39,6 +58,29 @@ TEST(MPI, CommunicatorSplit) {
   auto exp_ranks = std::array{0, 0, 0, 1};
   EXPECT_EQ(exp_sizes[rank], comm.size());
   EXPECT_EQ(exp_ranks[rank], comm.rank());
+
+  // duplicate the split communicator and check
+  auto dup = comm.duplicate();
+  EXPECT_EQ(comm.rank(), dup.rank());
+  EXPECT_EQ(comm.size(), dup.size());
+
+  // free the communicators
+  EXPECT_FALSE(dup.is_null());
+  EXPECT_FALSE(comm.is_null());
+  dup.free();
+  comm.free();
+  EXPECT_TRUE(dup.is_null());
+  EXPECT_TRUE(comm.is_null());
+}
+
+TEST(MPI_Window, CommunicatorSplitShared) {
+  mpi::communicator world;
+  [[maybe_unused]] auto shm = world.split_shared();
+}
+
+TEST(MPI, SharedCommunicatorDefaultConstructor) {
+  mpi::shared_communicator comm{};
+  EXPECT_TRUE(comm.is_null());
 }
 
 MPI_TEST_MAIN;

--- a/test/c++/mpi_group.cpp
+++ b/test/c++/mpi_group.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2020-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Olivier Parcollet, Nils Wentzell
+
+#include <gtest/gtest.h>
+#include <mpi/mpi.hpp>
+
+#include <vector>
+
+TEST(MPI, GroupDefaultConstructor) {
+  mpi::group g;
+  EXPECT_TRUE(g.is_null());
+}
+
+TEST(MPI, GroupCommWorld) {
+  mpi::communicator world;
+
+  mpi::group g(world);
+  EXPECT_EQ(g.rank(), world.rank());
+  EXPECT_EQ(g.size(), world.size());
+
+  // move operations
+  auto g2 = std::move(g);
+  EXPECT_EQ(g2.rank(), world.rank());
+  EXPECT_EQ(g2.size(), world.size());
+  EXPECT_TRUE(g.is_null());
+}
+
+TEST(MPI, GroupInclude) {
+  mpi::communicator world;
+  mpi::group g(world);
+
+  // include every second rank
+  std::vector<int> ranks;
+  for (int i = 0; i < world.size(); i += 2) ranks.push_back(i);
+  auto g2 = g.include(ranks);
+  EXPECT_EQ(g2.size(), ranks.size());
+  if (std::ranges::find(ranks, world.rank()) != ranks.end()) {
+    EXPECT_EQ(world.rank(), ranks[g2.rank()]);
+  } else {
+    EXPECT_EQ(g2.rank(), MPI_UNDEFINED);
+  }
+
+  // include every second rank (starting from the back)
+  ranks.clear();
+  for (int i = world.size() - 1; i >= 0; i -= 2) ranks.push_back(i);
+  auto g3 = g.include(ranks);
+  EXPECT_EQ(g3.size(), ranks.size());
+  if (std::ranges::find(ranks, world.rank()) != ranks.end()) {
+    EXPECT_EQ(world.rank(), ranks[g3.rank()]);
+  } else {
+    EXPECT_EQ(g3.rank(), MPI_UNDEFINED);
+  }
+}
+
+MPI_TEST_MAIN;

--- a/test/c++/mpi_window.cpp
+++ b/test/c++/mpi_window.cpp
@@ -14,10 +14,16 @@
 //
 // Authors: Philipp Dumitrescu, Olivier Parcollet, Nils Wentzell
 
-#include <mpi/mpi.hpp>
-#include <mpi/vector.hpp>
 #include <gtest/gtest.h>
+#include <mpi/mpi.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
 #include <numeric>
+#include <span>
+#include <utility>
+#include <vector>
 
 // Test cases are adapted from slides and exercises of the HLRS course:
 // Introduction to the Message Passing Interface (MPI)
@@ -26,7 +32,7 @@
 // https://fs.hlrs.de/projects/par/par_prog_ws/pdf/mpi_3.1_rab.pdf
 // https://fs.hlrs.de/projects/par/par_prog_ws/practical/MPI31single.tar.gz
 
-TEST(MPI_Window, CommunicatorMember) {
+TEST(MPI, WindowCommunicatorMember) {
   mpi::communicator world;
 
   int data = world.rank();
@@ -39,7 +45,7 @@ TEST(MPI_Window, CommunicatorMember) {
   EXPECT_EQ(win_comm.size(), world.size());
 }
 
-TEST(MPI_Window, SharedCommMember) {
+TEST(MPI, WindowSharedCommunicatorMember) {
   auto shm = mpi::communicator{}.split_shared();
 
   mpi::shared_window<int> win{shm, 1};
@@ -50,16 +56,10 @@ TEST(MPI_Window, SharedCommMember) {
   EXPECT_EQ(sh_win_comm.size(), shm.size());
 }
 
-TEST(MPI_Window, SharedCommunicator) {
+TEST(MPI, WindowGetAttrBase) {
   mpi::communicator world;
-  [[maybe_unused]] auto shm = world.split_shared();
-}
 
-TEST(MPI_Window, GetAttrBase) {
-  mpi::communicator world;
-  int rank = world.rank();
-
-  int buffer = rank;
+  int buffer = world.rank();
   mpi::window<int> win{world, &buffer, 1};
 
   void *base_ptr = win.base();
@@ -67,7 +67,7 @@ TEST(MPI_Window, GetAttrBase) {
   EXPECT_EQ(base_ptr, &buffer);
 }
 
-TEST(MPI_Window, WindowAllocate) {
+TEST(MPI, WindowAllocate) {
   mpi::communicator world;
   int rank = world.rank();
 
@@ -75,14 +75,14 @@ TEST(MPI_Window, WindowAllocate) {
   *(win.base()) = rank;
 
   win.fence();
-  int rcv;
+  int rcv{};
   win.get(&rcv, 1, rank);
   win.fence();
 
   EXPECT_EQ(rcv, rank);
 }
 
-TEST(MPI_Window, PassiveTargetCommunication) {
+TEST(MPI, WindowPassiveTargetCommunication) {
   mpi::communicator world;
   if (world.size() < 2) { GTEST_SKIP() << "Test requires at least 2 processes\n"; }
   int rank = world.rank();
@@ -104,7 +104,7 @@ TEST(MPI_Window, PassiveTargetCommunication) {
   }
 }
 
-TEST(MPI_Window, ActiveTargetCommunication) {
+TEST(MPI, WindowActiveTargetCommunication) {
   mpi::communicator world;
   if (world.size() < 2) {
     // Target rank cannot be equal to origin rank (deadlocks), so we need at
@@ -132,23 +132,23 @@ TEST(MPI_Window, ActiveTargetCommunication) {
 
   if (rank == origin_rank) {
     win.start(target_group); // blocks until target_rank calls post()
-    int origin_addr[] = {42};
-    int origin_count  = 1;
-    win.put(origin_addr, origin_count, target_rank);
+    auto origin_arr  = std::array<int, 1>{42};
+    int origin_count = 1;
+    win.put(origin_arr.data(), origin_count, target_rank);
     win.complete();
   }
 }
 
-TEST(MPI_Window, GetAttrSize) {
+TEST(MPI, WindowGetAttrSize) {
   mpi::communicator world;
-  int buffer;
+  int buffer{};
   mpi::window<int> win{world, &buffer, 1};
 
   MPI_Aint size = win.size();
   EXPECT_EQ(size, sizeof(int));
 }
 
-TEST(MPI_Window, MoveConstructor) {
+TEST(MPI, WindowMoveConstructor) {
   mpi::communicator world;
   int i = 1;
   mpi::window<int> win1{world, &i, 1};
@@ -159,7 +159,7 @@ TEST(MPI_Window, MoveConstructor) {
   EXPECT_EQ(win1.base(), nullptr);
 }
 
-TEST(MPI_Window, NullptrSizeZero) {
+TEST(MPI, WindowNullptrSizeZero) {
   mpi::communicator world;
   mpi::window<int> win{world, nullptr, 0};
 
@@ -167,11 +167,11 @@ TEST(MPI_Window, NullptrSizeZero) {
   EXPECT_EQ(win.size(), 0);
 }
 
-TEST(MPI_Window, OneSidedGet) {
+TEST(MPI, WindowOneSidedGet) {
   mpi::communicator world;
   int const rank = world.rank();
 
-  int snd_buf, rcv_buf = -1;
+  int snd_buf{}, rcv_buf = -1;
   mpi::window<int> win{world, &snd_buf, 1};
   snd_buf = rank;
 
@@ -182,11 +182,11 @@ TEST(MPI_Window, OneSidedGet) {
   EXPECT_EQ(rcv_buf, rank);
 }
 
-TEST(MPI_Window, OneSidedPut) {
+TEST(MPI, WindowOneSidedPut) {
   mpi::communicator world;
   int const rank = world.rank();
 
-  int snd_buf, rcv_buf = -1;
+  int snd_buf{}, rcv_buf = -1;
   mpi::window<int> win{world, &rcv_buf, 1};
   snd_buf = rank;
 
@@ -197,13 +197,13 @@ TEST(MPI_Window, OneSidedPut) {
   EXPECT_EQ(rcv_buf, rank);
 }
 
-TEST(MPI_Window, RingOneSidedGet) {
+TEST(MPI, WindowRingOneSidedGet) {
   mpi::communicator world;
   int const rank = world.rank();
   int const size = world.size();
   int const left = (rank - 1 + size) % size;
 
-  int snd_buf, rcv_buf;
+  int snd_buf{}, rcv_buf{};
   mpi::window<int> win{world, &snd_buf, 1};
   snd_buf = rank;
 
@@ -219,13 +219,13 @@ TEST(MPI_Window, RingOneSidedGet) {
   EXPECT_EQ(sum, (size * (size - 1)) / 2);
 }
 
-TEST(MPI_Window, RingOneSidedPut) {
+TEST(MPI, WindowRingOneSidedPut) {
   mpi::communicator world;
   int const rank  = world.rank();
   int const size  = world.size();
   int const right = (rank + 1) % size;
 
-  int snd_buf, rcv_buf;
+  int snd_buf{}, rcv_buf{};
   mpi::window<int> win{world, &rcv_buf, 1};
   snd_buf = rank;
 
@@ -241,7 +241,7 @@ TEST(MPI_Window, RingOneSidedPut) {
   EXPECT_EQ(sum, (size * (size - 1)) / 2);
 }
 
-TEST(MPI_Window, RingOneSidedAllocShared) {
+TEST(MPI, WindowRingOneSidedAllocShared) {
   mpi::communicator world;
   auto shm           = world.split_shared();
   int const rank_shm = shm.rank();
@@ -264,7 +264,7 @@ TEST(MPI_Window, RingOneSidedAllocShared) {
   EXPECT_EQ(sum, (size_shm * (size_shm - 1)) / 2);
 }
 
-TEST(MPI_Window, RingOneSidedStoreWinAllocSharedSignal) {
+TEST(MPI, WindowRingOneSidedStoreWinAllocSharedSignal) {
   if (not mpi::has_env) {
     // Test doesn't make sense without MPI
     GTEST_SKIP();
@@ -284,9 +284,9 @@ TEST(MPI_Window, RingOneSidedStoreWinAllocSharedSignal) {
   int sum     = 0;
   int snd_buf = rank_shm;
 
-  MPI_Request rq;
+  MPI_Request rq{};
   MPI_Status status;
-  int snd_dummy, rcv_dummy;
+  int snd_dummy{}, rcv_dummy{};
 
   for (int i = 0; i < size_shm; ++i) {
     // ... The local Win_syncs are needed to sync the processor and real memory.
@@ -327,7 +327,7 @@ TEST(MPI_Window, RingOneSidedStoreWinAllocSharedSignal) {
   win.unlock();
 }
 
-TEST(MPI_Window, SharedArray) {
+TEST(MPI, WindowSharedArray) {
   mpi::communicator world;
   auto shm           = world.split_shared();
   int const rank_shm = shm.rank();
@@ -339,8 +339,8 @@ TEST(MPI_Window, SharedArray) {
 
   // Fill array with local rank in parallel by chunking the range into the communicator
   win.fence();
-  auto slice = itertools::chunk_range(0, array_view.size(), shm.size(), shm.rank());
-  for (auto i = slice.first; i < slice.second; ++i) { array_view[i] = i; }
+  auto slice = itertools::chunk_range(0, static_cast<std::ptrdiff_t>(array_view.size()), shm.size(), shm.rank());
+  for (auto i = slice.first; i < slice.second; ++i) { array_view[i] = static_cast<int>(i); }
   win.fence();
 
   // Total sum is just sum of numbers in interval [0, array_size)
@@ -348,7 +348,7 @@ TEST(MPI_Window, SharedArray) {
   EXPECT_EQ(sum, (array_size * (array_size - 1)) / 2);
 }
 
-TEST(MPI_Window, DistributedSharedArray) {
+TEST(MPI, WindowDistributedSharedArray) {
   mpi::communicator world;
   auto shm = world.split_shared();
 
@@ -396,8 +396,8 @@ TEST(MPI_Window, DistributedSharedArray) {
   // Fill array with global index (= local index + global offset)
   // We do this in parallel on each shared memory island by chunking the total range
   win.fence();
-  auto slice = itertools::chunk_range(0, array_view.size(), shm.size(), shm.rank());
-  for (auto i = slice.first; i < slice.second; ++i) { array_view[i] = i + offset; }
+  auto slice = itertools::chunk_range(0, static_cast<std::ptrdiff_t>(array_view.size()), shm.size(), shm.rank());
+  for (auto i = slice.first; i < slice.second; ++i) { array_view[i] = static_cast<int>(i + offset); }
   win.fence();
 
   // Calculate partial sum on head node of each shared memory island and

--- a/test/c++/mpi_window.cpp
+++ b/test/c++/mpi_window.cpp
@@ -163,7 +163,7 @@ TEST(MPI_Window, NullptrSizeZero) {
   mpi::communicator world;
   mpi::window<int> win{world, nullptr, 0};
 
-  EXPECT_EQ(win.data(), nullptr);
+  EXPECT_EQ(win.base(), nullptr);
   EXPECT_EQ(win.size(), 0);
 }
 


### PR DESCRIPTION
I have made quite a lot of changes. Most of them are very trivial and not directly concerned with the new types (`group`, `window`). They are part of a general clean up that should make the code, formatting and docs more consistent across other core libraries. I tried to separate the commits as much as possible.

Otherwise, the more important changes are probably in the `window` class. For example, I wrapped all MPI calls with `check_mpi_call` which throws an exception if the MPI call failed (we do this for all other MPI calls as well). That means all functions making direct calls to the MPI C library may throw. Now, nearly all functions in the `window` class were `noexcept`, so I am not sure that this is what we want.

Feel free to incorporate some of the changes into your PR if you think that they are helpful. Otherwise, it would probably be a good idea to discuss things in more detail.